### PR TITLE
Redesign exam question screen

### DIFF
--- a/app/(protected)/exam/[attemptId]/question/[index]/QuestionPageClient.tsx
+++ b/app/(protected)/exam/[attemptId]/question/[index]/QuestionPageClient.tsx
@@ -1,0 +1,171 @@
+'use client';
+import Link from 'next/link';
+import { useState, useTransition } from 'react';
+import ExamTimer from '@/components/ExamTimer';
+import QuestionForm from './question-form';
+import type { Choice, QuestionType } from '@prisma/client';
+import { saveAnswer, toggleMark } from '@/lib/client-actions';
+import { ReactNode } from 'react';
+
+type Props = {
+  attemptId: string;
+  attemptQuestionId: string;
+  orderIndex: number;
+  totalQuestions: number;
+  expiresAt: string;
+  templateName: string;
+  questionText: string;
+  questionType: QuestionType;
+  orderedChoiceIds: string[];
+  allChoices: Choice[];
+  initialSelectedChoiceIds: string[];
+  initialIsMarked: boolean;
+  isLocked: boolean;
+  finishButton: ReactNode;
+};
+
+export default function QuestionPageClient({
+  attemptId,
+  attemptQuestionId,
+  orderIndex,
+  totalQuestions,
+  expiresAt,
+  templateName,
+  questionText,
+  questionType,
+  orderedChoiceIds,
+  allChoices,
+  initialSelectedChoiceIds,
+  initialIsMarked,
+  isLocked,
+  finishButton,
+}: Props) {
+  const [selectedChoiceIds, setSelectedChoiceIds] = useState<string[]>(initialSelectedChoiceIds);
+  const [isMarked, setIsMarked] = useState<boolean>(initialIsMarked);
+  const [isPending, startTransition] = useTransition();
+
+  const handleSaveAnswer = () =>
+    startTransition(async () => {
+      await saveAnswer({ attemptQuestionId, selectedChoiceIds });
+    });
+
+  const handleToggleReviewMark = () =>
+    startTransition(async () => {
+      const next = !isMarked;
+      const ok = await toggleMark({ attemptQuestionId, next });
+      if (ok) setIsMarked(next);
+    });
+
+  const handleReset = () => {
+    if (isLocked || isPending) return;
+    setSelectedChoiceIds([]);
+  };
+
+  return (
+    <div className="flex h-screen flex-col">
+      {/* Top header */}
+      <header className="flex items-center justify-between bg-blue-800 px-4 py-2 text-white">
+        <div className="font-semibold">{templateName}</div>
+        <Link href="#" className="underline text-sm">
+          Instructions
+        </Link>
+      </header>
+
+      {/* Sub header */}
+      <div className="flex items-center justify-between bg-blue-100 px-4 py-2 text-sm">
+        <div className="flex items-center gap-4">
+          <label className="flex items-center gap-1">
+            <input
+              type="checkbox"
+              checked={isMarked}
+              onChange={handleToggleReviewMark}
+              disabled={isLocked || isPending}
+            />
+            Mark
+          </label>
+          <span>
+            Question {orderIndex} / {totalQuestions}
+          </span>
+        </div>
+        <ExamTimer expiresAt={expiresAt} />
+      </div>
+
+      {/* Question body */}
+      <main className="flex-1 overflow-y-auto bg-gray-50 p-4">
+        <div className="mx-auto max-w-4xl rounded-md border bg-white p-6">
+          <div className="mb-4 whitespace-pre-wrap text-lg font-medium">{questionText}</div>
+          <QuestionForm
+            questionType={questionType}
+            orderedChoiceIds={orderedChoiceIds}
+            allChoices={allChoices}
+            selectedChoiceIds={selectedChoiceIds}
+            onChangeSelected={setSelectedChoiceIds}
+            isLocked={isLocked}
+          />
+        </div>
+      </main>
+
+      {/* Bottom actions */}
+      <footer className="flex flex-wrap items-center gap-2 border-t bg-gray-100 px-4 py-3">
+        {orderIndex > 1 && (
+          <Link
+            className="rounded-md bg-gray-200 px-4 py-2"
+            href={`/exam/${attemptId}/question/${orderIndex - 1}`}
+          >
+            前へ
+          </Link>
+        )}
+        <button
+          type="button"
+          onClick={handleReset}
+          disabled={isLocked || isPending}
+          className="rounded-md bg-gray-200 px-4 py-2"
+        >
+          リセット
+        </button>
+        <button
+          type="button"
+          onClick={handleToggleReviewMark}
+          disabled={isLocked || isPending}
+          className={`rounded-md px-4 py-2 ${isMarked ? 'bg-yellow-400 text-white' : 'bg-yellow-200'}`}
+        >
+          {isMarked ? '見直し解除' : '見直し'}
+        </button>
+        <button
+          type="button"
+          onClick={handleSaveAnswer}
+          disabled={isLocked || isPending}
+          className="rounded-md border bg-white px-4 py-2"
+        >
+          回答を保存
+        </button>
+        {orderIndex < totalQuestions && (
+          <Link
+            className="rounded-md bg-blue-600 px-4 py-2 text-white"
+            href={`/exam/${attemptId}/question/${orderIndex + 1}`}
+          >
+            次へ
+          </Link>
+        )}
+        <Link
+          className="ml-auto rounded-md px-4 py-2 border"
+          href={`/exam/${attemptId}/summary`}
+        >
+          サマリー
+        </Link>
+        <Link
+          className="rounded-md px-4 py-2 border"
+          href={`/exam/${attemptId}/review`}
+        >
+          見直し一覧
+        </Link>
+        {finishButton}
+      </footer>
+      {isLocked && (
+        <div className="border-t bg-amber-100 px-4 py-3 text-sm text-amber-800">
+          時間切れです。回答や見直しはできません。「終了して採点」を押してください。
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/(protected)/exam/[attemptId]/question/[index]/question-form.tsx
+++ b/app/(protected)/exam/[attemptId]/question/[index]/question-form.tsx
@@ -1,131 +1,77 @@
 'use client';
 import type { Choice, QuestionType } from '@prisma/client';
-import { useEffect, useMemo, useState, useTransition } from 'react';
-import { saveAnswer, toggleMark } from '@/lib/client-actions';
+import { useMemo } from 'react';
 
 type QuestionFormProps = {
-  /** この試行中の特定の1問を識別するID */
-  attemptQuestionId: string;
   /** 問題タイプ（単一選択 or 複数選択） */
   questionType: QuestionType;
   /** 表示順に並んだ選択肢ID */
   orderedChoiceIds: string[];
   /** 全選択肢のオブジェクト（id/textなど） */
   allChoices: Choice[];
-  /** 初期の選択済み選択肢ID */
-  initialSelectedChoiceIds: string[];
-  /** 初期状態で見直しフラグが立っているか */
-  initialIsMarked: boolean;
+  /** 現在選択されている選択肢ID */
+  selectedChoiceIds: string[];
+  /** 選択肢の変更ハンドラ */
+  onChangeSelected: (ids: string[]) => void;
   /** ロック中（時間切れ等）かどうか */
   isLocked: boolean;
 };
 
-export default function QuestionForm(props: QuestionFormProps) {
-  const {
-    attemptQuestionId,
-    questionType,
-    orderedChoiceIds,
-    allChoices,
-    initialSelectedChoiceIds,
-    initialIsMarked,
-    isLocked,
-  } = props;
-
-  // UI 状態（選択、見直し、送信中）
-  const [selectedChoiceIds, setSelectedChoiceIds] = useState<string[]>(initialSelectedChoiceIds);
-  const [isMarked, setIsMarked] = useState<boolean>(initialIsMarked);
-  const [isPending, startTransition] = useTransition();
-
-  // 親（サーバー再描画など）から初期値が変わった場合に同期
-  useEffect(() => setSelectedChoiceIds(initialSelectedChoiceIds), [initialSelectedChoiceIds]);
-  useEffect(() => setIsMarked(initialIsMarked), [initialIsMarked]);
-
+export default function QuestionForm({
+  questionType,
+  orderedChoiceIds,
+  allChoices,
+  selectedChoiceIds,
+  onChangeSelected,
+  isLocked,
+}: QuestionFormProps) {
   // id→Choice の逆引き用に Map を作成
-  const choiceMap = useMemo(() => new Map(allChoices.map(c => [c.id, c])), [allChoices]);
+  const choiceMap = useMemo(() => new Map(allChoices.map((c) => [c.id, c])), [allChoices]);
 
   // 画面に表示する順番の Choice 配列（存在しないIDは安全のため除外）
   const orderedChoices: Choice[] = useMemo(
-    () => orderedChoiceIds.map(id => choiceMap.get(id)).filter((c): c is Choice => Boolean(c)),
+    () => orderedChoiceIds.map((id) => choiceMap.get(id)).filter((c): c is Choice => Boolean(c)),
     [orderedChoiceIds, choiceMap]
   );
 
   // 選択変更（単一選択なら置き換え、複数選択ならトグル）
   const handleToggleSelectChoice = (id: string) => {
-    if (isLocked || isPending) return;
+    if (isLocked) return;
     if (questionType === 'SINGLE') {
-      setSelectedChoiceIds([id]);
+      onChangeSelected([id]);
     } else {
-      setSelectedChoiceIds(prev => (prev.includes(id) ? prev.filter(x => x !== id) : [...prev, id]));
+      onChangeSelected(
+        selectedChoiceIds.includes(id)
+          ? selectedChoiceIds.filter((x) => x !== id)
+          : [...selectedChoiceIds, id]
+      );
     }
   };
 
-  // 回答を保存（API 経由）
-  const handleSaveAnswer = () =>
-    startTransition(async () => {
-      // 既存の API はレスポンスを返さず内部で warn を出す仕様
-      await saveAnswer({ attemptQuestionId, selectedChoiceIds });
-    });
-
-  // 見直しフラグのトグル（API 成功時のみローカル状態反映）
-  const handleToggleReviewMark = () =>
-    startTransition(async () => {
-      const next = !isMarked;
-      const ok = await toggleMark({ attemptQuestionId, next });
-      if (ok) setIsMarked(next);
-      else console.warn('Failed to toggle mark');
-    });
-
-  const inputName = `choice-${attemptQuestionId}`; // ラジオのグルーピング名（他フォームと衝突しないように）
-
   return (
-    <div className="space-y-4" aria-busy={isPending} aria-live="polite">
-      <div className="space-y-2">
-        {orderedChoices.map(choice => {
-          const checked = selectedChoiceIds.includes(choice.id);
-          const isSingle = questionType === 'SINGLE';
-          return (
-            <label
-              key={choice.id}
-              className={`flex items-start gap-3 p-3 border rounded-md bg-white ${
-                isLocked ? 'opacity-60' : ''
-              }`}
-            >
-              <input
-                type={isSingle ? 'radio' : 'checkbox'}
-                name={inputName}
-                className="mt-1"
-                checked={checked}
-                onChange={() => handleToggleSelectChoice(choice.id)}
-                disabled={isLocked || isPending}
-              />
-              <span className="whitespace-pre-wrap">{choice.text}</span>
-            </label>
-          );
-        })}
-      </div>
-
-      <div className="flex gap-3">
-        <button
-          type="button"
-          onClick={handleSaveAnswer}
-          disabled={isLocked || isPending}
-          className="px-3 py-2 bg-blue-600 text-white rounded-md"
-        >
-          回答を保存
-        </button>
-
-        <button
-          type="button"
-          onClick={handleToggleReviewMark}
-          disabled={isLocked || isPending}
-          className={`px-3 py-2 rounded-md border ${
-            isMarked ? 'bg-yellow-100 border-yellow-300' : ''
-          }`}
-          aria-pressed={isMarked}
-        >
-          {isMarked ? '見直しから外す' : '見直しに追加'}
-        </button>
-      </div>
+    <div className="space-y-2">
+      {orderedChoices.map((choice) => {
+        const checked = selectedChoiceIds.includes(choice.id);
+        const isSingle = questionType === 'SINGLE';
+        return (
+          <label
+            key={choice.id}
+            className={`flex items-start gap-3 p-3 border rounded-md bg-white ${
+              isLocked ? 'opacity-60' : ''
+            }`}
+          >
+            <input
+              type={isSingle ? 'radio' : 'checkbox'}
+              name="choice"
+              className="mt-1"
+              checked={checked}
+              onChange={() => handleToggleSelectChoice(choice.id)}
+              disabled={isLocked}
+            />
+            <span className="whitespace-pre-wrap">{choice.text}</span>
+          </label>
+        );
+      })}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Refactor exam question page to use new QuestionPageClient with top header, mark controls, timer, and redesigned action bar
- Simplify QuestionForm to be presentational and controlled externally
- Pass server-side finish button and data to client component

## Testing
- `npm run lint`
- `npm run build` *(fails: @clerk/clerk-react: Missing publishableKey)*

------
https://chatgpt.com/codex/tasks/task_e_68c80d1095e4832c80d71f0f22eba20c